### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/react-native-home-indicator.podspec
+++ b/react-native-home-indicator.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
 
   s.source_files = "ios/**/*.{h,m}"
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
Xcode 12 fails to build if a module depends on React instead of React-Core.
Reference: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116