### PR TITLE
remove old style React header imports

### DIFF
--- a/ios/RNHomeIndicator.h
+++ b/ios/RNHomeIndicator.h
@@ -1,9 +1,4 @@
-
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 #import <UIKit/UIKit.h>
 


### PR DESCRIPTION
These old style header imports cause issues with Expo SDK 44.
see https://github.com/expo/expo/issues/15622