### PR TITLE
Add return type to home indicator component

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -6,7 +6,7 @@ const isIos = Platform.OS === "ios";
 
 type Props = { autoHidden: boolean };
 
-export const HomeIndicator = (props: Props) => {
+export const HomeIndicator: React.FC<Props> = (props) => {
     useEffect(() => {
         if (!isIos) return;
 


### PR DESCRIPTION
Thank you for making this library and for adding TypeScript to it! When updating to v0.2.9 I found that although the properties are now properly typed, my TS configuration still gave me a warning:

> error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.

By only typing the props, the HomeIndicator component was missing a clear return type. This proposed change instead types the functional component, setting the return type to be a React Functional Component that will accept the properties defined in Props.

Cheers!